### PR TITLE
Revert sudo access requirement for npm install on osx/linux

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -434,8 +434,7 @@ module.exports = function (grunt) {
       },
       updateDependencies: {
         cmd: function() {
-          var sudoPrefix = process.platform !== 'win32' ? 'sudo' : '';
-          return util.format('%s npm prune && %s npm install && bower install', sudoPrefix, sudoPrefix);
+          return 'npm prune && npm install && bower install';
         }
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -433,9 +433,7 @@ module.exports = function (grunt) {
         }
       },
       updateDependencies: {
-        cmd: function() {
-          return 'npm prune && npm install && bower install';
-        }
+        cmd: 'npm prune && npm install && bower install'
       }
     },
     htmllint: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,9 +3,6 @@
 
 'use strict';
 
-// Load util
-var util = require('util');
-
 // Directory reference:
 //   css: css
 //   javascript: js


### PR DESCRIPTION
`fixes #67` Revert sudo access requirement for npm install on osx/linux fixed

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe.github.io/73)
<!-- Reviewable:end -->
